### PR TITLE
Add support for options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ Set Up
 4. Deploy to your server, and play with it.
 
 5. See testclient/index.html for a working one.
+
+Options
+=======
+GetSentry provides the possibility to add additional options to your Raven
+config, such as `whitelistUrls`. These options can be submitted using the
+`options` key in the config object.
+
+```
+    angular.module("yourModule", ["angular-raven"])
+        .value("RavenConfig", {
+            ravenUrl: "http://yourravenhash@yourdomain.com/1", // this should be your raven endpoint URL
+            options: {
+                whitelistUrls: ['example.com/scripts/']
+            }
+    });
+```

--- a/angular-raven.js
+++ b/angular-raven.js
@@ -28,7 +28,8 @@
     ngRaven.config(["$provide", function ($provide) {
         $provide.decorator("$exceptionHandler", ["RavenConfig", "$delegate", function (cfg, del) {
             if (!cfg) { throw new Error("Raven config must be set before using this"); }
-            Raven.config(cfg.ravenUrl).install();
+            cfg.options = cfg.options || {};
+            Raven.config(cfg.ravenUrl, cfg.options).install();
             return function (ex, cause) {
                 del(ex, cause);
                 Raven.captureException(ex, cause);


### PR DESCRIPTION
This change adds support for additional options when configuring Raven.
GetSentry allows for passing optional parameters such as `whitelistUrls`
which helps filter out clutter.
